### PR TITLE
Support missing or blank timestamps in properties shortcodes

### DIFF
--- a/layouts/shortcodes/properties.html
+++ b/layouts/shortcodes/properties.html
@@ -1,17 +1,52 @@
+
+{{/* srcstart is neither missing nor an empty string. */}}
+{{ $hasSrcStart := .Get "srcstart" }}
+
+{{/* srcend is neither missing nor an empty string. */}}
+{{ $hasSrcEnd := .Get "srcend" }}
+
+{{/* If embedding audio */}}
 {{ if (.Get "srcmp3audiourl") }}
 
-<audio
-  controls
-  preload="auto" 
-  src="{{ .Get "srcmp3audiourl" }}#t={{ .Get "srcstart" | safeHTML }},{{ .Get "srcend" | safeHTML }}"
-  title="{{ .Get "srctitle" }}">
+{{ $srcmp3audiourl := .Get "srcmp3audiourl" }}
 
+{{ $srcstart := "00:00" }}
+{{ if $hasSrcStart }}
+  {{ $srcstart = .Get "srcstart" }}
+{{ end }}
+
+{{ $srcend := "" }}
+{{ if $hasSrcEnd }}
+  {{ $srcend = printf ",%s" (.Get "srcend") }}
+{{ end }}
+
+{{ $audiourl := printf "%s#t=%s%s" $srcmp3audiourl $srcstart $srcend }}
+
+<audio controls preload="auto" title="{{ .Get "srctitle" }}">
+  <source src="{{ $audiourl }}" type="audio/mpeg">
+</audio>
+
+{{/* If embedding video */}}
 {{ else if (.Get "srcyoutubevideoid") }}
+
+{{ $srcyoutubevideoid := .Get "srcyoutubevideoid" }}
+
+{{ $srcstart := "0" }}
+{{ if $hasSrcStart }}
+  {{ $srcstart = .Get "srcstart" }}
+{{ end }}
+
+{{ $srcend := "" }}
+{{ if $hasSrcEnd }}
+  {{ $srcend = printf "&end=%s" (.Get "srcend") }}
+{{ end }}
+
+{{ $videourl := printf "https://www.youtube.com/embed/%s?start=%s%s" $srcyoutubevideoid $srcstart $srcend }}
 
 <iframe
   width="560"
   height="315"
-  src="https://www.youtube.com/embed/{{ .Get "srcyoutubevideoid" }}?start={{ .Get "srcstart" }}&end={{ .Get "srcend" }}"
+  {{ printf "src=%q" $videourl | safeHTMLAttr }}
   title="{{ .Get "srctitle" }}"
   frameborder="0" 
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
I spent *forever* trying to get the ampersand before `end` in the video URL string to not be escaped. The way Hugo templates handle `safeHTML`, `safeURL`, etc. is excessively unintuitive when paired with local variables. In my opinion.

I'm sure once you are more familiar with Go templating this sort of thing isn't so terrible, but it was very fiddly for me. So what should have been 15 minutes turned into two and half hours of trial and error to get the ampersand to not be escaped. This is why I wish the templating language was more like normal programming: it shouldn't take me two hours to figure out how to turn what is essentially logically correct into the correct string format.  But alas.

For testing purposes, I added some text to a file:

```markdown
### Audio: Both start and end specified

{{< properties 

srcmp3audiourl="https://ichthys.com/MP3/sr5-pt1-ak.mp3"
srctitle="SR5 Audio Subpart 1"
srcstart="00:17"
srcend="04:10"

>}}

<!-- --- -->

### Audio: Start missing and end specified

{{< properties 

srcmp3audiourl="https://ichthys.com/MP3/sr5-pt1-ak.mp3"
srctitle="SR5 Audio Subpart 1"
srcend="04:10"

>}}

<!-- --- -->

### Audio: Start blank and end specified

{{< properties 

srcmp3audiourl="https://ichthys.com/MP3/sr5-pt1-ak.mp3"
srctitle="SR5 Audio Subpart 1"
srcstart=""
srcend="04:10"

>}}

<!-- --- -->

### Audio: Start specified and end missing

{{< properties 

srcmp3audiourl="https://ichthys.com/MP3/sr5-pt1-ak.mp3"
srctitle="SR5 Audio Subpart 1"
srcstart="00:17"

>}}

<!-- --- -->

### Audio: Start specified and end blank

{{< properties 

srcmp3audiourl="https://ichthys.com/MP3/sr5-pt1-ak.mp3"
srctitle="SR5 Audio Subpart 1"
srcstart="00:17"
srcend=""

>}}

<!-- --- -->

### Video: Both start and end specified

{{< properties

srcyoutubevideoid="8yfhG547two"
srctitle="Who was Charlemagne?"
srcstart="1569"
srcend="1630"

>}}

<!-- --- -->

### Video: Start missing and end specified

{{< properties

srcyoutubevideoid="8yfhG547two"
srctitle="Who was Charlemagne?"
srcend="1630"

>}}

<!-- --- -->

### Video: Start blank and end specified

{{< properties

srcyoutubevideoid="8yfhG547two"
srctitle="Who was Charlemagne?"
srcstart=""
srcend="1630"

>}}

<!-- --- -->

### Video: Start specified and end missing

{{< properties

srcyoutubevideoid="8yfhG547two"
srctitle="Who was Charlemagne?"
srcstart="1569"

>}}

<!-- --- -->

### Video: Start specified and end blank

{{< properties

srcyoutubevideoid="8yfhG547two"
srctitle="Who was Charlemagne?"
srcstart="1569"
srcend=""

>}}
```

And then checked the HTML file in the `public` directory generated by the `hugo` command.

This PR matches this commit in the pre-processor repo:  https://github.com/StevenTammen/victor/commit/e6cfd832339d7350f3cbd7d8c19dabdfb4a43af1